### PR TITLE
Add reCaptcha support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
+.idea
 hugo-mx-gateway

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Regardless of the deployment platform (Google App Engine, Kubernetes, Docker), t
 * `CONTACT_REPLY_BCC_EMAIL`: Sets an email address for bcc copy of the email sent to the user. This is useful for tracking and follow up.
 * `DEMO_URL`: Specific for demo forms, it can be used to set the URL of the demo site that will be included to the user reply email (e.g. `https://demo.example.com/`). 
 * `ALLOWED_ORIGINS`: Set a list of comma-separated domains that the `hugo-mx-gateway` App shoudl trust. This is for security reason to filter requests. Only requests with an `Origin` header belonging to the defined origins will be accepted, through it's only required that the request has a valid `Referer` header. It's expected in the future to these request filtering and admission rules.
+* `RECAPTCHA_PRIVATE_KEY` (optional): The [reCaptcha](https://www.google.com/recaptcha/intro/v3.html) private key.
 * `TEMPLATE_DEMO_REQUEST_REPLY` (optional): Specify the path of the template to reply a demo request. The default templare is `templates/template_reply_demo_request.html`
 * `TEMPLATE_CONTACT_REQUEST_REPLY` (optional): Specify the path of the template to reply a contact request. The default templare is `templates/template_reply_contact_request.html`.
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module hugo-mx-gateway
 go 1.13
 
 require (
+	github.com/dpapathanasiou/go-recaptcha v0.0.0-20190121160230-be5090b17804
 	github.com/gorilla/mux v1.7.4
 	github.com/sirupsen/logrus v1.2.0
 	github.com/spf13/viper v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/dpapathanasiou/go-recaptcha v0.0.0-20190121160230-be5090b17804 h1:gFnPvL9HX+Nrb4M2AwzFYqcwGStxYZpuDpFAqpViBG4=
+github.com/dpapathanasiou/go-recaptcha v0.0.0-20190121160230-be5090b17804/go.mod h1:eovtlS/D2AGk8vy2a9sO4XzOyHMHb8jM+WPsf9pkgFo=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/main.go
+++ b/main.go
@@ -40,7 +40,9 @@ var routes = Routes{
 		"SendMail",
 		"POST",
 		"/sendmail",
-		MuxSecAllowedDomainsHandler(http.HandlerFunc(SendMail)),
+		MuxSecAllowedDomainsHandler(
+			MuxSecReCaptchaHandler(
+				http.HandlerFunc(SendMail))),
 	},
 	Route{
 		"Healthz",

--- a/main.go
+++ b/main.go
@@ -27,10 +27,10 @@ import (
 )
 
 type Route struct {
-	Name        string
-	Method      string
-	Pattern     string
-	HandlerFunc http.HandlerFunc
+	Name    string
+	Method  string
+	Pattern string
+	Handler http.Handler
 }
 
 type Routes []Route
@@ -40,13 +40,13 @@ var routes = Routes{
 		"SendMail",
 		"POST",
 		"/sendmail",
-		SendMail,
+		MuxSecAllowedDomainsHandler(http.HandlerFunc(SendMail)),
 	},
 	Route{
 		"Healthz",
 		"GET",
 		"/healthz",
-		Healthz,
+		http.HandlerFunc(Healthz),
 	},
 }
 
@@ -67,9 +67,7 @@ func MuxLoggerHandler(inner http.Handler, name string) http.Handler {
 func NewRouter() *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)
 	for _, route := range routes {
-		var handler http.Handler
-		handler = route.HandlerFunc
-		handler = MuxLoggerHandler(handler, route.Name)
+		handler := MuxLoggerHandler(route.Handler, route.Name)
 
 		router.
 			Methods(route.Method).

--- a/samples/hugo-partial-contact-form.html
+++ b/samples/hugo-partial-contact-form.html
@@ -3,6 +3,9 @@
    <fieldset>
       <legend>Please fill in the form to submit your request</legend>
       <form action="https://contact-request-endpoint/" method="post">
+         <!-- uncomment this div block when enabling reCaptcha
+         <script src="https://www.google.com/recaptcha/api.js"></script>
+         -->
          <div class="form-item">
             <label for="name">Name</label>
             <input type="text" name="name" id="name"  placeholder="Mr. Smith" />
@@ -15,7 +18,7 @@
             <label for="organization">Organization</label>
             <input type="text" name="organization" id="organization"  placeholder="Company, Inc." />
          </div>
-         {{ if in .Params.tags "contact" }}  
+         {{ if in .Params.tags "contact" }}
          <div class="form-item">
             <label for="subject">Subject</label>
             <input type="text" name="subject" id="subject"  value="" placeholder="Need help or expertise?" />
@@ -25,12 +28,15 @@
             <label for="message">Message</label>
             <textarea  rows="6" name="message" id="message"  placeholder="Please add details concerning your request."></textarea>
          </div>
-         {{ else }}    
+         {{ else }}
          <div class="form-item">
             <input type="hidden" name="subject" id="subject"  value="Your Access to Product Demo!" />
             <input type="hidden" name="target" id="target"  value="demo" />
          </div>
          {{ end }}
+         <!-- uncomment the below div when enabling reCaptcha
+         <div class="g-recaptcha" data-sitekey="{{.Site.Params.reCaptchaPrivateKey}}"></div>
+         -->
          <input  class="button"  type="submit" value="Submit">
       </form>
    </fieldset>

--- a/vendor/github.com/dpapathanasiou/go-recaptcha/.gitignore
+++ b/vendor/github.com/dpapathanasiou/go-recaptcha/.gitignore
@@ -1,0 +1,4 @@
+*~
+*.a
+*.swp
+example/example

--- a/vendor/github.com/dpapathanasiou/go-recaptcha/LICENSE
+++ b/vendor/github.com/dpapathanasiou/go-recaptcha/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+Copyright (c) 2012-2016 Denis Papathanasiou
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/dpapathanasiou/go-recaptcha/README.md
+++ b/vendor/github.com/dpapathanasiou/go-recaptcha/README.md
@@ -1,0 +1,56 @@
+go-recaptcha
+============
+
+https://godoc.org/github.com/dpapathanasiou/go-recaptcha
+
+About
+-----
+
+This package handles [reCaptcha](https://www.google.com/recaptcha) (API versions [2](https://developers.google.com/recaptcha/intro) and [3](https://developers.google.com/recaptcha/docs/v3)) form submissions in [Go](http://golang.org/).
+
+Usage
+-----
+
+Install the package in your environment:
+
+```
+go get github.com/dpapathanasiou/go-recaptcha
+```
+
+To use it within your own code, import <tt>github.com/dpapathanasiou/go-recaptcha</tt> and call:
+
+```
+recaptcha.Init (recaptchaPrivateKey)
+```
+
+once, to set the reCaptcha private key for your domain, then:
+
+```
+recaptcha.Confirm (clientIpAddress, recaptchaResponse)
+```
+
+### [reCAPTCHA v2](https://developers.google.com/recaptcha/intro)
+For each reCaptcha form input you need to check, using the values obtained by reading the form's POST parameters (the <tt>recaptchaResponse</tt> in the above corresponds to the value of <tt>g-recaptcha-response</tt> sent by the reCaptcha server.)
+
+The recaptcha.Confirm() function returns either true (i.e., the captcha was completed correctly) or false, along with any errors (from the HTTP io read or the attempt to unmarshal the JSON reply).
+
+### [reCAPTCHA v3](https://developers.google.com/recaptcha/docs/v3)
+
+Version 3 works differently: instead of interrupting page visitors with a prompt, it runs in the background, computing a score.
+
+This repo has been updated to handle the [score and action in the response](recaptcha.go#L20), but the usage example is still in terms of version 2.
+
+Usage Example
+-------------
+
+Included with this repo is [example.go](example/example.go), a simple HTTP server which creates the reCaptcha form and tests the input.
+
+See the [instructions](example/README.md) for running the example for more details.
+
+## Donate
+
+If you find this work useful, please consider making a donation:
+
+<a href="bitcoin:14TM4ADKJbaGEi8Qr8dh4KfPBQmjTshkZ2">Bitcoin Donate</a> `14TM4ADKJbaGEi8Qr8dh4KfPBQmjTshkZ2`
+
+![QR code](https://bitref.com/qr.php?data=14TM4ADKJbaGEi8Qr8dh4KfPBQmjTshkZ2)

--- a/vendor/github.com/dpapathanasiou/go-recaptcha/recaptcha.go
+++ b/vendor/github.com/dpapathanasiou/go-recaptcha/recaptcha.go
@@ -1,0 +1,71 @@
+// Package recaptcha handles reCaptcha (http://www.google.com/recaptcha) form submissions
+//
+// This package is designed to be called from within an HTTP server or web framework
+// which offers reCaptcha form inputs and requires them to be evaluated for correctness
+//
+// Edit the recaptchaPrivateKey constant before building and using
+package recaptcha
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+type RecaptchaResponse struct {
+	Success     bool      `json:"success"`
+	Score       float64   `json:"score"`
+	Action      string    `json:"action"`
+	ChallengeTS time.Time `json:"challenge_ts"`
+	Hostname    string    `json:"hostname"`
+	ErrorCodes  []string  `json:"error-codes"`
+}
+
+const recaptchaServerName = "https://www.google.com/recaptcha/api/siteverify"
+
+var recaptchaPrivateKey string
+
+// check uses the client ip address, the challenge code from the reCaptcha form,
+// and the client's response input to that challenge to determine whether or not
+// the client answered the reCaptcha input question correctly.
+// It returns a boolean value indicating whether or not the client answered correctly.
+func check(remoteip, response string) (r RecaptchaResponse, err error) {
+	resp, err := http.PostForm(recaptchaServerName,
+		url.Values{"secret": {recaptchaPrivateKey}, "remoteip": {remoteip}, "response": {response}})
+	if err != nil {
+		log.Printf("Post error: %s\n", err)
+		return
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Println("Read error: could not read body: %s", err)
+		return
+	}
+	err = json.Unmarshal(body, &r)
+	if err != nil {
+		log.Println("Read error: got invalid JSON: %s", err)
+		return
+	}
+	return
+}
+
+// Confirm is the public interface function.
+// It calls check, which the client ip address, the challenge code from the reCaptcha form,
+// and the client's response input to that challenge to determine whether or not
+// the client answered the reCaptcha input question correctly.
+// It returns a boolean value indicating whether or not the client answered correctly.
+func Confirm(remoteip, response string) (result bool, err error) {
+	resp, err := check(remoteip, response)
+	result = resp.Success
+	return
+}
+
+// Init allows the webserver or code evaluating the reCaptcha form input to set the
+// reCaptcha private key (string) value, which will be different for every domain.
+func Init(key string) {
+	recaptchaPrivateKey = key
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,3 +1,5 @@
+# github.com/dpapathanasiou/go-recaptcha v0.0.0-20190121160230-be5090b17804
+github.com/dpapathanasiou/go-recaptcha
 # github.com/fsnotify/fsnotify v1.4.7
 github.com/fsnotify/fsnotify
 # github.com/gorilla/mux v1.7.4


### PR DESCRIPTION
This PR adds [reCaptcha](https://developers.google.com/recaptcha/docs/display) support as an additional security layer against unwanted / spam form submission.

This is a fairly straighforward implementation which verifies the challenge code in the `g-recaptcha-response` POST parameter, if available.

Feel free to make any comment on this one. 😌

<img width="599" alt="image" src="https://user-images.githubusercontent.com/9574336/83551947-48081780-a509-11ea-9b80-0cc0e997683e.png">
