### PR TITLE
Allow specifying listen address

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,6 +77,7 @@ func main() {
 	viper.SetDefault("EMAIL_SUBJECT", "Thanks to try our product")
 	viper.SetDefault("DEMO_URL", "http://company.com/product-demo")
 
+	host := os.Getenv("HOST")
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8080"
@@ -90,5 +91,5 @@ func main() {
 
 	log.Printf("Listening on port %s", port)
 
-	log.Fatal(http.ListenAndServe(":"+port, nil))
+	log.Fatal(http.ListenAndServe(host+":"+port, nil))
 }


### PR DESCRIPTION
This allows specifying a listen address, which is especially important if running outside a container.

The default is empty, leading to the same behaviour as before.