### PR TITLE
Send Origin back as Access-Control-Allow-Origin

### DIFF
--- a/sendmail.go
+++ b/sendmail.go
@@ -176,6 +176,9 @@ func MuxSecAllowedDomainsHandler(next http.Handler) http.Handler {
 			return
 		}
 
+		// Send the allowed origin back as CORS header
+		w.Header().Set("Access-Control-Allow-Origin", r.Header["Origin"][0])
+
 		next.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
Rationale: At this point, we have already verified that the Origin is
allowed. Some clients, e.g. those that submit a form using AJAX, will
expect a CORS header allowing the request. Instead of setting
Access-Control-Allow-Origin *, or setting the header to all allowed
origins (thus leaking a list of sites that use the gateway), we can
thus simply set the same Origin the browser identifies with.