### PR TITLE
Fix: small typo in sendmail.go

### DIFF
--- a/app.yaml.sample
+++ b/app.yaml.sample
@@ -12,7 +12,7 @@ env_variables:
   TEMPLATE_DEMO_REQUEST_REPLY: templates/template_reply_demo_request.html
   TEMPLATE_CONTACT_REQUEST_REPLY: templates/template_reply_contact_request.html
   SMTP_SERVER_ADDR: "smtp.mailgun.org:587"
-  SMTP_VERITY_CERT: true
+  SMTP_SKIP_VERIFY_CERT: false
   SMTP_AUTHENTICATION_ENABLED: true
   SMTP_CLIENT_USERNAME: "postmaster@example.com"
   SMTP_CLIENT_PASSWORD: "postmasterSecretPassWord"

--- a/docs/configuration-variables.md
+++ b/docs/configuration-variables.md
@@ -3,7 +3,7 @@
 Regardless of the deployment platform (Google App Engine, Kubernetes, Docker), the following configuration parameters must be provided when deploying hugo-mx-gateway.
 
 * `SMTP_SERVER_ADDR`: Set the address of the SMTP server in the form of `host:port`. It's required that the SMTP server being supporting TLS.
-* `SMTP_VERITY_CERT`: Tell whether the SMTP certificate should be validated against top level authorities. If you're using a self-signed certificate on the SMTP server, this value must be set to `false`.
+* `SMTP_SKIP_VERIFY_CERT`: Tell whether the SMTP certificate should be validated against top level authorities. If you're using a self-signed certificate on the SMTP server, this value should be set to `false`.
 * `SMTP_AUTHENTICATION_ENABLED`: Boolean (default: `true`) indicating whether SMTP authentication is required or not. If true, the variables `SMTP_CLIENT_USERNAME` and `SMTP_CLIENT_PASSWORD` are used the perform the authentication.
 * `SMTP_CLIENT_USERNAME`: Set the username to connect to the SMTP server.
 * `SMTP_CLIENT_PASSWORD`: Set the password to connect to the SMTP server.

--- a/docs/configuration-variables.md
+++ b/docs/configuration-variables.md
@@ -3,7 +3,7 @@
 Regardless of the deployment platform (Google App Engine, Kubernetes, Docker), the following configuration parameters must be provided when deploying hugo-mx-gateway.
 
 * `SMTP_SERVER_ADDR`: Set the address of the SMTP server in the form of `host:port`. It's required that the SMTP server being supporting TLS.
-* `SMTP_SKIP_VERIFY_CERT`: Tell whether the SMTP certificate should be validated against top level authorities. If you're using a self-signed certificate on the SMTP server, this value should be set to `false`.
+* `SMTP_SKIP_VERIFY_CERT`: Tell whether the SMTP certificate should be validated against top level authorities. If you're using a self-signed certificate on the SMTP server, this value should be set to `true`.
 * `SMTP_AUTHENTICATION_ENABLED`: Boolean (default: `true`) indicating whether SMTP authentication is required or not. If true, the variables `SMTP_CLIENT_USERNAME` and `SMTP_CLIENT_PASSWORD` are used the perform the authentication.
 * `SMTP_CLIENT_USERNAME`: Set the username to connect to the SMTP server.
 * `SMTP_CLIENT_PASSWORD`: Set the password to connect to the SMTP server.

--- a/docs/deployment-on-docker.md
+++ b/docs/deployment-on-docker.md
@@ -11,7 +11,7 @@ Then apply the following command while setting the configuration variables appro
     --publish 8080:8080 \
     --name 'hugo-mx-gateway' \
     -e SMTP_SERVER_ADDR="smtp.example.com:465" \
-    -e SMTP_VERITY_CERT=true \
+    -e SMTP_SKIP_VERIFY_CERT=false \
     -e SMTP_CLIENT_USERNAME="postmaster@example.com" \
     -e SMTP_CLIENT_PASSWORD="postmasterSecretPassWord" \
     -e CONTACT_REPLY_EMAIL="noreply@example.com" \

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 envs:
   SMTP_SERVER_ADDR: "smtp.mailgun.org:587"
-  SMTP_VERITY_CERT: true
+  SMTP_SKIP_VERIFY_CERT: false
   SMTP_CLIENT_USERNAME: "postmaster@example.com"
   SMTP_CLIENT_PASSWORD: "postmasterSecretPassWord"
   ALLOWED_ORIGINS: "127.0.0.1,example.com"

--- a/sendmail.go
+++ b/sendmail.go
@@ -78,7 +78,7 @@ func (m *SendMailRequest) Execute() error {
 
 	// TLS config
 	tlsconfig := &tls.Config{
-		InsecureSkipVerify: viper.GetBool("SMTP_VERITY_CERT"),
+		InsecureSkipVerify: viper.GetBool("SMTP_SKIP_VERIFY_CERT"),
 		ServerName:         smtpServerHost,
 	}
 


### PR DESCRIPTION
Hey guys, great job! I found a small type in the environment variable `SMTP_VERITY_CERT`. Additionally, I would suggest to rename the variable to `SMTP_SKIP_VERIFY_CERT` because the action in `tlsconfig` can be more clearly understood, I think. What so you mean?