### PR TITLE
Implement honeypot anti-spam measure

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,10 +17,10 @@ limitations under the License.
 package main
 
 import (
+	"log"
 	"net/http"
 	"os"
 	"time"
-	"log"
 
 	"github.com/spf13/viper"
 )
@@ -40,8 +40,9 @@ var routes = Routes{
 		"POST",
 		"/sendmail",
 		MuxSecAllowedDomainsHandler(
-			MuxSecReCaptchaHandler(
-				http.HandlerFunc(SendMail))),
+			MuxSecHoneypotHandler(
+				MuxSecReCaptchaHandler(
+					http.HandlerFunc(SendMail)))),
 	},
 	Route{
 		"Healthz",


### PR DESCRIPTION
This implements basic spam prevention which does not require a captcha provider.

It is supposed to stop basic spam bots that just fill out a form and send it. There is some background on [SO](https://stackoverflow.com/questions/3622433/how-effective-is-the-honeypot-technique-against-spam) and [here](https://nedbatchelder.com/text/stopbots.html#h_formfilling_bots).

The way to use it is by adding HTML similar to this to your form:

```html
<label style="display:none">
  Please leave this field blank: <input type="text" name="x-honeypot-email" value="" autocomplete="off" tabindex="-1" />
</label>
```