### PR TITLE
Fix typos and incorrect URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![logo-thumbnail](hugo-mx-gateway-thumbnail.png)
 
-![Apache License](https://img.shields.io/github/license/rchakode/kube-opex-analytics.svg?label=License&style=for-the-badge)
-[![GitHub Actions Status](<https://img.shields.io/github/workflow/status/rchakode/hugo-mx-gateway/Build?logo=GitHub&style=for-the-badge>)](https://github.com/rchakode/kube-opex-analytics/actions)
+![Apache License](https://img.shields.io/github/license/rchakode/hugo-mx-gateway.svg?label=License&style=for-the-badge)
+[![GitHub Actions Status](https://img.shields.io/github/actions/workflow/status/rchakode/hugo-mx-gateway/build.yml?logo=GitHub&style=for-the-badge)](https://github.com/rchakode/hugo-mx-gateway/actions)
 ![Docker pulls](https://raster.shields.io/docker/pulls/rchakode/hugo-mx-gateway.png?label=Docker%20Pulls&style=for-the-badge)
 
 
@@ -24,8 +24,8 @@ You're at the right place.
 # Getting Started
 The following resources will enable you to deploy and get started with hugo-mx-gateway.
 
-* [Deployment on Kubenetes](./docs/deployment-on-kubernetes.md)
-* [Deployment on Google Computing Engine](./docs/deployment-on-kubernetes.md)
+* [Deployment on Kubernetes](./docs/deployment-on-kubernetes.md)
+* [Deployment on Google Compute Engine](./docs/deployment-on-google-compute-engine.md)
 * [Deployment on Docker](./docs/deployment-on-docker.md)
 * [Deployment on Debian](./docs/deployment-on-debian.md)
 * [Configuration Variables](./docs/configuration-variables.md)
@@ -35,7 +35,7 @@ The following resources will enable you to deploy and get started with hugo-mx-g
 # License & Copyrights
 This tool (code and documentation) is licensed under the terms of Apache 2.0 License. Read the [LICENSE](LICENSE) file for more details on the license terms.
 
-The tool may inlcude third-party libraries provided with their owns licenses and copyrights, but always compatible with the Apache 2.0 License terms of use.
+The tool may include third-party libraries provided with their own licenses and copyrights, but always compatible with the Apache 2.0 License terms of use.
 
 # Support & Contributions
 We encourage feedback and do make our best to handle any troubles you may encounter when using this tool.


### PR DESCRIPTION
## Summary
- Corrects license and GitHub Actions badge URLs to point to the correct repository
- Fixes typos in documentation links (Kubernetes, Google Compute Engine)
- Fixes minor spelling errors in the license section

## Test plan
- [ ] Verify badge images render correctly on GitHub
- [ ] Verify documentation links navigate to correct pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)